### PR TITLE
core: Add auto-size to window

### DIFF
--- a/engine/include/vull/core/Window.hh
+++ b/engine/include/vull/core/Window.hh
@@ -5,6 +5,7 @@
 #include <vull/core/Input.hh>
 #include <vull/maths/Vec.hh>
 #include <vull/support/Function.hh>
+#include <vull/support/Optional.hh>
 #include <vull/vulkan/Swapchain.hh>
 #include <vull/vulkan/Vulkan.hh>
 
@@ -22,8 +23,8 @@ class Context;
 namespace vull {
 
 class Window {
-    const uint16_t m_width;
-    const uint16_t m_height;
+    uint16_t m_width;
+    uint16_t m_height;
     xcb_connection_t *m_connection;
     xcb_intern_atom_reply_t *m_delete_window_atom{nullptr};
     uint32_t m_id{0};
@@ -49,7 +50,13 @@ class Window {
     Key translate_keycode(uint8_t keycode);
 
 public:
-    Window(uint16_t width, uint16_t height, bool fullscreen);
+    /**
+     * Create a new window and make it visible.
+     * @param width      width in pixels of the new window. if nullopt, match the root screen width
+     * @param height     height in pixels of the new window. if nullopt, match the root screen height
+     * @param fullscreen true to make window fullscreen, false otherwise
+     */
+    Window(Optional<uint16_t> width, Optional<uint16_t> height, bool fullscreen);
     Window(const Window &) = delete;
     Window(Window &&) = delete;
     ~Window();

--- a/engine/include/vull/support/Optional.hh
+++ b/engine/include/vull/support/Optional.hh
@@ -25,6 +25,9 @@ public:
     Optional &operator=(const Optional &);
     Optional &operator=(Optional &&);
 
+    template <typename U>
+    T value_or(U &&fallback) const;
+
     void clear();
     template <typename... Args>
     T &emplace(Args &&...args);
@@ -103,6 +106,12 @@ Optional<T> &Optional<T>::operator=(Optional &&other) {
         }
     }
     return *this;
+}
+
+template <typename T>
+template <typename U>
+T Optional<T>::value_or(U &&fallback) const {
+    return m_present ? **this : static_cast<T>(vull::forward<U>(fallback));
 }
 
 template <typename T>

--- a/sandbox/main.cc
+++ b/sandbox/main.cc
@@ -51,6 +51,8 @@
 #include <vull/vulkan/Swapchain.hh>
 #include <vull/vulkan/Vulkan.hh>
 
+#include <stdint.h>
+
 using namespace vull;
 
 namespace vull::vk {
@@ -81,7 +83,7 @@ void vull_main(Vector<StringView> &&args) {
         }
     }
 
-    Window window(2560, 1440, true);
+    Window window({}, {}, true);
     vk::Context context(enable_validation);
     auto swapchain = window.create_swapchain(context, vk::SwapchainMode::LowPower);
 


### PR DESCRIPTION
Add an option to allow window to automatically size itself to the dimensions of the root X screen.

Now the window size in the sandbox does not have to be hard-coded.