### PR TITLE
ci: Update to LLVM 19 trunk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
  && wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key \
   | gpg --dearmor - \
   > /usr/share/keyrings/llvm-archive-keyring.gpg \
- && echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy-16 main' > /etc/apt/sources.list.d/llvm.list \
+ && echo 'deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] https://apt.llvm.org/jammy/ llvm-toolchain-jammy main' > /etc/apt/sources.list.d/llvm.list \
  && wget -O - http://packages.lunarg.com/lunarg-signing-key-pub.asc \
   | gpg --dearmor - \
   > /usr/share/keyrings/lunarg-archive-keyring.gpg \
@@ -23,15 +23,15 @@ RUN apt-get update \
  && apt-add-repository ppa:ubuntu-toolchain-r/ppa \
  && apt-get update \
  && apt-get install -y \
-      clang-16 \
-      clang-format-16 \
-      clang-tidy-16 \
-      clang-tools-16 \
+      clang-19 \
+      clang-format-19 \
+      clang-tidy-19 \
+      clang-tools-19 \
       cmake \
       gcc-12 \
       g++-12 \
       git \
-      libclang-16-dev \
+      libclang-19-dev \
       libfreetype-dev \
       libharfbuzz-dev \
       libstdc++-12-dev \
@@ -41,7 +41,7 @@ RUN apt-get update \
       libxcb-xkb-dev \
       libxxhash-dev \
       libzstd-dev \
-      llvm-16-dev \
+      llvm-19-dev \
       ninja-build \
       parallel \
       shaderc \
@@ -49,21 +49,21 @@ RUN apt-get update \
    /var/lib/apt/lists/* \
  && git clone \
    --depth 1 \
-   --branch 0.20 \
+   --branch master \
    https://github.com/include-what-you-use/include-what-you-use.git \
  && cmake \
    -Biwyu-build \
    -GNinja \
    -DCMAKE_BUILD_TYPE=Release \
-   -DCMAKE_PREFIX_PATH=/usr/lib/llvm-16 \
+   -DCMAKE_PREFIX_PATH=/usr/lib/llvm-19 \
    -DCMAKE_INSTALL_PREFIX=/usr \
    ./include-what-you-use \
  && ninja -Ciwyu-build install \
- && rm /usr/lib/clang/16/include \
- && cp -r iwyu-build/lib/clang/16/include/ /usr/lib/clang/16/include/ \
+ && rm /usr/lib/clang/19/include \
+ && cp -r iwyu-build/lib/clang/19/include/ /usr/lib/clang/19/include/ \
  && rm -r include-what-you-use iwyu-build \
- && ln -s /usr/bin/clang-16 /usr/bin/clang \
- && ln -s /usr/bin/clang++-16 /usr/bin/clang++ \
- && ln -s /usr/bin/clang-format-16 /usr/bin/clang-format \
- && ln -s /usr/bin/clang-tidy-16 /usr/bin/clang-tidy \
+ && ln -s /usr/bin/clang-19 /usr/bin/clang \
+ && ln -s /usr/bin/clang++-19 /usr/bin/clang++ \
+ && ln -s /usr/bin/clang-format-19 /usr/bin/clang-format \
+ && ln -s /usr/bin/clang-tidy-19 /usr/bin/clang-tidy \
  && ln -s /usr/bin/g++-12 /usr/bin/g++


### PR DESCRIPTION
Has a fix for the ICE noticed in Clang 17.